### PR TITLE
FIX getting the page 1 for twice, that of last page not downloaded

### DIFF
--- a/src/jcomicdownloader/module/ParseEC.java
+++ b/src/jcomicdownloader/module/ParseEC.java
@@ -120,8 +120,8 @@ public class ParseEC extends ParseOnlineComicSite {
         NView_Java nv = new NView_Java(Integer.parseInt(chs), Integer.parseInt(itemid), allcodes, ch);
         this.comicURL = new String[nv.getPagesCount()];
         nv.setPage(1);
-        for (int d = 0; d < nv.getPagesCount(); nv.setPage(++d)) {
-            this.comicURL[d] = nv.parse();
+        for (int d = 1; d <= nv.getPagesCount(); nv.setPage(++d)) {
+            this.comicURL[d - 1] = nv.parse();
         }
     }
 


### PR DESCRIPTION
I think have written codes too much, that forgot about the pages of books should start from index of 1...

\* Where's your enum jcomicdownloader.enums.Site.PTT? you seems haven't pushed the new Site.java yet. 