### PR TITLE
Switch to use GitHub API for new releases info provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ https://java.net/projects/substance/
 https://bitbucket.org/ijabz/jaudiotagger/
 * jsoup <br/>
 http://jsoup.org/
+* Genson<br/>
+http://owlike.github.io/genson/
 
 ## Icon Information
 [Double-J Design](http://www.doublejdesign.co.uk/)

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <systemPath>${project.basedir}/lib/trident.jar</systemPath>
         </dependency> -->
         <dependency>
+            <groupId>com.owlike</groupId>
+            <artifactId>genson</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.8.2</version>

--- a/src/main/java/jcomicdownloader/tools/Common.java
+++ b/src/main/java/jcomicdownloader/tools/Common.java
@@ -794,7 +794,7 @@ public class Common
             URL url = new URL( urlString );
 
             HttpURLConnection connection = ( HttpURLConnection ) url.openConnection();
-            connection.setRequestProperty( "User-Agent", "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; zh-TW; rv:1.9.2.8) Gecko/20100722 Firefox/3.6.8" );
+            connection.setRequestProperty( "User-Agent", "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0" );
 
             connection.connect();
 


### PR DESCRIPTION
As talked in [#10](https://github.com/abc9070410/JComicDownloader/issues/10#issuecomment-117195888).

The result of getting JSON of latest release using GitHub API could be seen [here](https://api.github.com/repos/abc9070410/JComicDownloader/releases/latest), and [FYI, the API reference](https://developer.github.com/v3/repos/releases/#get-the-latest-release). 